### PR TITLE
add es2020 dynamic module import

### DIFF
--- a/can-import-module-test.js
+++ b/can-import-module-test.js
@@ -15,6 +15,26 @@ if(!isNode) {
 				assert.ok(false, err);
 			});
 		});
+
+		QUnit.test('es2020 dynamic import', function(assert) {
+			this.oldSystem = global.System;
+			global.System.import = null; // disable steals SystemJS
+			return load('/test/es6-module.js', __dirname).then(function(data) {
+				assert.equal(data.default, 'Hello world');
+			}).then(null, function(err){
+				assert.ok(false, err);
+			});
+		});
+
+		QUnit.test('es2020 dynamic import without file extension', function(assert) {
+			this.oldSystem = global.System;
+			global.System.import = null; // disable steals SystemJS
+			return load('/test/es6-module', __dirname).then(function(data) {
+				assert.equal(data.default, 'Hello world');
+			}).then(null, function(err){
+				assert.ok(false, err);
+			});
+		});
 	}
 } else {
 	QUnit.module('can-util/js/import - Node', {

--- a/can-import-module.js
+++ b/can-import-module.js
@@ -4,8 +4,7 @@ var getGlobal = require("can-globals/global/global");
 var namespace = require("can-namespace");
 
 /**
- * @module {function} can-util/js/import/import import
- * @parent can-util/js
+ * @module module:can-import-module
  * @signature `importModule(moduleName, parentName)`
  * @hide
  *
@@ -36,14 +35,16 @@ module.exports = namespace.import = function(moduleName, parentName) {
 				});
 			} else if(global.require){
 				resolve(global.require(moduleName));
-			} else {
+			} else if(typeof stealRequire !== "undefined"){
 				// steal optimized build
-				if (typeof stealRequire !== "undefined") {
-					steal.import(moduleName, { name: parentName }).then(resolve, reject);
-				} else {
-					// ideally this will use can.getObject
-					resolve();
-				}
+				steal.import(moduleName, { name: parentName }).then(resolve, reject);
+			} else if("noModule" in HTMLScriptElement.prototype){
+				if(!(moduleName.match(/[^\\\/]\.([^.\\\/]+)$/) || [null]).pop()){
+					moduleName += '.js';
+				} 
+				import(moduleName).then(resolve, reject);
+			}else{
+				reject("no proper module-loader available");
 			}
 		} catch(err) {
 			reject(err);

--- a/test/es6-module.js
+++ b/test/es6-module.js
@@ -1,0 +1,1 @@
+export default 'Hello world';


### PR DESCRIPTION
this PR adds the possibility to load javascipt modules with the dynamic-import syntax.

if this PR is accepted, i maybe can remove this weired stuff:
https://github.com/pYr0x/vite-plugin-stache/commit/1198ebc6c7af9c5d5d22d40d4b1bef227e3cc16b#diff-a2a171449d862fe29692ce031981047d7ab755ae7f84c707aef80701b3ea0c80R135