### PR TITLE
Add package.json for local tests to prevent error during npm install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
-node_js: node
+node_js: 12
 dist: xenial
 services:
   - xvfb

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "preversion": "npm test",
     "postpublish": "git push --tags && git push",
-    "testee": "testee test.html --browsers firefox",
+    "testee": "DEBUG=testee:* testee test.html --browsers firefox",
     "mocha": "mocha -- test/node-test.js",
     "test": "npm run jshint && npm run mocha && npm run testee",
     "jshint": "jshint ./*.js --config",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "preversion": "npm test",
     "postpublish": "git push --tags && git push",
-    "testee": "DEBUG=testee:* testee test.html --browsers firefox --timeout 240",
+    "testee": "DEBUG=testee:* testee test.html --browsers firefox",
     "mocha": "mocha -- test/node-test.js",
     "test": "npm run jshint && npm run mocha && npm run testee",
     "jshint": "jshint ./*.js --config",
@@ -36,7 +36,7 @@
     "jshint": "^2.9.1",
     "mocha": "^9.1.3",
     "steal": "^2.2.1",
-    "steal-qunit": "^1.0.1",
+    "steal-qunit": "^2.0.0",
     "steal-tools": "^2.2.1",
     "testee": "^0.9.0"
   },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "scripts": {
     "preversion": "npm test",
     "postpublish": "git push --tags && git push",
-    "testee": "DEBUG=testee:* testee test.html --browsers firefox",
+    "testee": "DEBUG=testee:* testee test.html --browsers firefox --timeout 240",
     "mocha": "mocha -- test/node-test.js",
     "test": "npm run jshint && npm run mocha && npm run testee",
     "jshint": "jshint ./*.js --config",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "release:patch": "npm version patch && npm publish",
     "release:minor": "npm version minor && npm publish",
     "release:major": "npm version major && npm publish",
-   "release:pre": "npm version prerelease && npm publish --tag=pre",
+    "release:pre": "npm version prerelease && npm publish --tag=pre",
     "develop": "done-serve --static --develop --port 8080"
   },
   "main": "can-import-module.js",
@@ -32,13 +32,13 @@
   ],
   "devDependencies": {
     "assert": "^2.0.0",
+    "can-import-module-test": "file:test",
     "jshint": "^2.9.1",
     "mocha": "^9.1.3",
     "steal": "^2.2.1",
     "steal-qunit": "^1.0.1",
     "steal-tools": "^2.2.1",
-    "testee": "^0.9.0",
-    "can-import-module-test": "file:./test"
+    "testee": "^0.9.0"
   },
   "license": "MIT",
   "dependencies": {

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,1 @@
+import './browser-test';

--- a/test/package.json
+++ b/test/package.json
@@ -1,0 +1,4 @@
+{
+	"name": "can-import-module-test",
+	"version": "0.1.0"
+}


### PR DESCRIPTION
The local `test.js` was thrown an error during installation with `6.14.15`:
- adding `package.json` to the test folder and update the `package.json` `devDependecnies` for the local tests.