### PR TITLE
Make es6 loader able to be transpiled to amd format for bundling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 node_js: node
-dist: xenial
+dist: focal
 services:
   - xvfb

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: node_js
 node_js: node
+addons:
+  firefox: latest
 dist: focal
 services:
   - xvfb

--- a/build-test.js
+++ b/build-test.js
@@ -1,0 +1,10 @@
+var stealTools = require("steal-tools");
+
+stealTools.build({
+	main: "can-import-module/test",
+	config: __dirname + "/package.json!npm"
+},{
+	minify: false,
+	debug: true,
+	bundleAssets: true
+});

--- a/build.js
+++ b/build.js
@@ -1,13 +1,29 @@
 "use strict";
 var stealTools = require("steal-tools");
+var path = require("path");
+
+function ignorer(path) {
+	return path.indexOf("can-import-module") < 0;
+}
 
 stealTools.export({
 	steal: {
-		config: __dirname + "/package.json!npm"
+		config: __dirname + "/package.json!npm",
+    paths: {
+      "can-import-module/loader/es6.js": "compat-loader/es6.js"
+    }
 	},
 	outputs: {
-		"+cjs": {},
-		"+amd": {},
+		"+bundled-cjs": {
+			modules: ["can-import-module/can-import-module"],
+			dest: path.join(__dirname, "dist", "cjs", "can-import-module.js"),
+	    ignore: ignorer
+		},
+		"+bundled-amd": {
+			modules: ["can-import-module/can-import-module"],
+			dest: path.join(__dirname, "dist", "amd", "can-import-module.js"),
+	    ignore: ignorer
+		},
 		"+global-js": {}
 	}
 }).catch(function(e){

--- a/can-import-module.js
+++ b/can-import-module.js
@@ -59,6 +59,7 @@ function preset(preset){
 			addLoader(require("./loader/system"));
 			break;
 		case "ES2020":
+		case "es2020":
 		case "dynamic-import":
 			addLoader(require("./loader/es6"));
 			break;

--- a/compat-loader/es6.js
+++ b/compat-loader/es6.js
@@ -1,0 +1,17 @@
+var getGlobal = require("can-globals/global/global");
+
+// check for `noModule` in HTMLScriptElement. if its present, then the browser can handle dynamic loading because if
+// HTMLScriptElement.noModule is `true` the browser used to run fallback scripts in older browsers that do not support JavaScript modules
+if ("HTMLScriptElement" in getGlobal() && "noModule" in HTMLScriptElement.prototype) {
+	// "import()" is a syntax error on some platforms and will cause issues if this module is bundled
+	//  into a larger script bundle, so only eval it to code if the platform is known to support it.
+	module.exports = new Function("function esImport(moduleName) {\n" +
+		// if moduleName has no extension, treat it as a javascript file and add .js extension
+		"if (!(moduleName.match(/[^\\\/]\.([^.\\\/]+)$/) || [null]).pop()) {\n" +
+			"moduleName += '.js';\n" +
+		"}\n" +
+		"return import(moduleName.replace(/['\"]+/g, ''));\n" +
+	"}");
+} else {
+	module.exports = function() {}
+}

--- a/loader/es6.js
+++ b/loader/es6.js
@@ -1,11 +1,17 @@
-module.exports = function(moduleName) {
-	// check for `noModule` in HTMLScriptElement. if its present, then the browser can handle dynamic loading because if
-	// HTMLScriptElement.noModule is `true` the browser used to run fallback scripts in older browsers that do not support JavaScript modules
-	if ("noModule" in HTMLScriptElement.prototype) {
+var getGlobal = require("can-globals/global/global");
+
+// check for `noModule` in HTMLScriptElement. if its present, then the browser can handle dynamic loading because if
+// HTMLScriptElement.noModule is `true` the browser used to run fallback scripts in older browsers that do not support JavaScript modules
+if ("HTMLScriptElement" in getGlobal() && "noModule" in HTMLScriptElement.prototype) {
+	module.exports = new Function("function esImport(moduleName) {\n" +
 		// if moduleName has no extension, threat it as a javascript file and add .js extension
-		if (!(moduleName.match(/[^\\\/]\.([^.\\\/]+)$/) || [null]).pop()) {
-			moduleName += '.js';
-		}
-		return import(moduleName.replace(/['"]+/g, ''));
+		"if (!(moduleName.match(/[^\\\/]\.([^.\\\/]+)$/) || [null]).pop()) {\n" +
+			"moduleName += '.js';\n" +
+		"}\n" +
+		"return import(moduleName.replace(/['\"]+/g, ''));\n" +
+	"}");
+} else {
+	module.exports = function() {
+		throw new Error("ES dynamic imports are not available on this platform");
 	}
-};
+}

--- a/loader/es6.js
+++ b/loader/es6.js
@@ -3,8 +3,10 @@ var getGlobal = require("can-globals/global/global");
 // check for `noModule` in HTMLScriptElement. if its present, then the browser can handle dynamic loading because if
 // HTMLScriptElement.noModule is `true` the browser used to run fallback scripts in older browsers that do not support JavaScript modules
 if ("HTMLScriptElement" in getGlobal() && "noModule" in HTMLScriptElement.prototype) {
+	// "import()" is a syntax error on some platforms and will cause issues if this module is bundled
+	//  into a larger script bundle, so only eval it to code if the platform is known to support it.
 	module.exports = new Function("function esImport(moduleName) {\n" +
-		// if moduleName has no extension, threat it as a javascript file and add .js extension
+		// if moduleName has no extension, treat it as a javascript file and add .js extension
 		"if (!(moduleName.match(/[^\\\/]\.([^.\\\/]+)$/) || [null]).pop()) {\n" +
 			"moduleName += '.js';\n" +
 		"}\n" +

--- a/loader/es6.js
+++ b/loader/es6.js
@@ -1,19 +1,13 @@
 var getGlobal = require("can-globals/global/global");
 
-// check for `noModule` in HTMLScriptElement. if its present, then the browser can handle dynamic loading because if
-// HTMLScriptElement.noModule is `true` the browser used to run fallback scripts in older browsers that do not support JavaScript modules
-if ("HTMLScriptElement" in getGlobal() && "noModule" in HTMLScriptElement.prototype) {
-	// "import()" is a syntax error on some platforms and will cause issues if this module is bundled
-	//  into a larger script bundle, so only eval it to code if the platform is known to support it.
-	module.exports = new Function("function esImport(moduleName) {\n" +
-		// if moduleName has no extension, treat it as a javascript file and add .js extension
-		"if (!(moduleName.match(/[^\\\/]\.([^.\\\/]+)$/) || [null]).pop()) {\n" +
-			"moduleName += '.js';\n" +
-		"}\n" +
-		"return import(moduleName.replace(/['\"]+/g, ''));\n" +
-	"}");
-} else {
-	module.exports = function() {
-		throw new Error("ES dynamic imports are not available on this platform");
+module.exports = function(moduleName) {
+	// check for `noModule` in HTMLScriptElement. if its present, then the browser can handle dynamic loading because if
+	// HTMLScriptElement.noModule is `true` the browser used to run fallback scripts in older browsers that do not support JavaScript modules
+	if ("HTMLScriptElement" in getGlobal() && "noModule" in HTMLScriptElement.prototype) {
+		// if moduleName has no extension, threat it as a javascript file and add .js extension
+		if (!(moduleName.match(/[^\\\/]\.([^.\\\/]+)$/) || [null]).pop()) {
+			moduleName += '.js';
+		}
+		return import(moduleName.replace(/['"]+/g, ''));
 	}
-}
+};

--- a/package.json
+++ b/package.json
@@ -13,15 +13,19 @@
     "url": ""
   },
   "scripts": {
+    "build": "node build.js",
+    "build:test": "node build-test.js",
     "preversion": "npm test",
     "postpublish": "git push --tags && git push",
     "testee": "testee test.html --browsers firefox",
+    "testee:production": "testee test.html --browsers firefox",
     "mocha": "mocha -- test/node-test.js",
     "test": "npm run jshint && npm run mocha && npm run testee",
+    "test:production": "npm run build:test && npm run testee:production",
     "jshint": "jshint ./*.js --config",
-    "release:patch": "npm version patch && npm publish",
-    "release:minor": "npm version minor && npm publish",
-    "release:major": "npm version major && npm publish",
+    "release:patch": "npm run build && npm version patch && npm publish",
+    "release:minor": "npm run build && npm version minor && npm publish",
+    "release:major": "npm run build && npm version major && npm publish",
     "release:pre": "npm version prerelease && npm publish --tag=pre",
     "develop": "done-serve --static --develop --port 8080"
   },
@@ -32,13 +36,14 @@
   ],
   "devDependencies": {
     "assert": "^2.0.0",
+    "can-import-module-test": "file:./test",
     "jshint": "^2.9.1",
     "mocha": "^9.1.3",
-    "steal": "^2.2.1",
-    "steal-qunit": "^1.0.1",
-    "steal-tools": "^2.2.1",
-    "testee": "^0.9.0",
-    "can-import-module-test": "file:./test"
+    "steal": "^2.3.0",
+    "steal-css": "^1.3.2",
+    "steal-qunit": "^2.0.0",
+    "steal-tools": "^2.3.0",
+    "testee": "^0.9.0"
   },
   "license": "MIT",
   "dependencies": {

--- a/test-production.html
+++ b/test-production.html
@@ -1,0 +1,4 @@
+<!DOCTYPE html>
+<title>CanJS production tests</title>
+<script src="dist/steal.production.js" main="can-import-module/test" env="canjs-test"></script>
+<div id="qunit-fixture"></div>

--- a/test.js
+++ b/test.js
@@ -1,4 +1,1 @@
-// preload for production tests
-import 'can-import-module/test/cjs-module';
-
 import './test/browser-test';

--- a/test.js
+++ b/test.js
@@ -1,1 +1,4 @@
+// preload for production tests
+import 'can-import-module/test/cjs-module';
+
 import './test/browser-test';

--- a/test/browser-test.js
+++ b/test/browser-test.js
@@ -1,6 +1,23 @@
 var QUnit = require('steal-qunit');
 var moduleImport = require( '../can-import-module');
 
+var prefix;
+QUnit.module('can-import-module', {
+	before: function() {
+		if(QUnit.config.modules.length > 1) {
+			prefix = {
+				npm: "can-import-module/test",
+				esm: "/node_modules/can-import-module/test"
+			};
+		} else {
+			prefix = {
+				npm: "~/test",
+				esm: "/test"
+			};
+		}
+	}
+})
+
 QUnit.test('load npm library via default config (SystemJS first)', function(assert) {
 	return moduleImport('can-import-module/test/cjs-module').then(function(data) {
 		assert.equal(data, 'Hello from cjs-module');
@@ -11,7 +28,7 @@ QUnit.test('load npm library via default config (SystemJS first)', function(asse
 
 QUnit.test('load es6 module with dynamic import', function(assert) {
 	moduleImport.preset('es2020');
-	return moduleImport('/test/es6-module').then(function(module) {
+	return moduleImport(prefix.esm + '/es6-module').then(function(module) {
 		assert.equal(module.default, 'Hello from es6-module');
 	}).then(null, function(err){
 		assert.ok(false, err);
@@ -25,7 +42,7 @@ QUnit.test('custom loader', function(assert){
 		return import(moduleName.replace('cjs', 'es6'));
 	});
 
-	return moduleImport('/test/cjs-module.js').then(function(module) {
+	return moduleImport(prefix.esm + '/cjs-module.js').then(function(module) {
 		assert.equal(module.default, 'Hello from es6-module', 'es6 module loaded');
 	}).then(null, function(err){
 		assert.ok(false, err);
@@ -34,7 +51,7 @@ QUnit.test('custom loader', function(assert){
 
 QUnit.test('presets', function(assert){
 	moduleImport.preset('node');
-	return moduleImport('/test/cjs-module.js').then(function() {
+	return moduleImport(prefix.npm + '/cjs-module.js').then(function() {
 		assert.ok(false);
 	}, function(err){
 		assert.equal(err, 'no proper module-loader available');

--- a/test/es6-module.js
+++ b/test/es6-module.js
@@ -1,3 +1,1 @@
-'use strict';
-
 export default 'Hello from es6-module';

--- a/test/es6-module.js
+++ b/test/es6-module.js
@@ -1,1 +1,3 @@
+'use strict';
+
 export default 'Hello from es6-module';

--- a/test/node-test.js
+++ b/test/node-test.js
@@ -25,16 +25,16 @@ describe('nodeJS', function (){
 });
 
 describe('es6 module', function() {
-	it('throws an error when trying to import in es6 style', function() {
+	it('does not syntax error when trying to import in es6 style', function() {
 		load.flushLoader();
 		load.addLoader(require('../loader/es6'));
-		return load('/test/es6-module').then(function() {
-			assert.fail("es6 loader did not throw error when expected");
+		return load('/test/es6-module').then(function(result) {
+			assert.fail("es6 loader did not reject when expected");
 		}, function(err) {
 			assert.equal(
-				err.message,
-				'ES dynamic imports are not available on this platform',
-				'Correct error message returned from import attempt'
+				err,
+				'no proper module-loader available',
+				'Incorrect error message returned from import attempt: ' + err
 			);
 		});
 	});

--- a/test/node-test.js
+++ b/test/node-test.js
@@ -23,3 +23,19 @@ describe('nodeJS', function (){
 		});
 	});
 });
+
+describe('es6 module', function() {
+	it('throws an error when trying to import in es6 style', function() {
+		load.flushLoader();
+		load.addLoader(require('../loader/es6'));
+		return load('/test/es6-module').then(function() {
+			assert.fail("es6 loader did not throw error when expected");
+		}, function(err) {
+			assert.equal(
+				err.message,
+				'ES dynamic imports are not available on this platform',
+				'Correct error message returned from import attempt'
+			);
+		});
+	});
+});


### PR DESCRIPTION
instead of changing loader/es6.js itself, provide a compat module that can be bundled into canjs rollup packages for unknown platforms (e.g. global build for nodejs).

Also add production tests and fix a discrepancy between the preset strings 'ES2020' (expected by the code) and 'es2020'  (used in the test).